### PR TITLE
Fix CLI: add --output option to set output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Additional command line arguments are given below:
                         use this face
 -t TARGET_PATH, --target TARGET_PATH
                         replace this face
+-o OUTPUT_FILE, --output OUTPUT_FILE
+                      save output to this file
 --keep-fps            keep original fps
 --gpu                 use gpu
 --keep-frames         don't delete frames directory

--- a/run.py
+++ b/run.py
@@ -20,6 +20,7 @@ args = {}
 parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--face', help='use this face', dest='source_img')
 parser.add_argument('-t', '--target', help='replace this face', dest='target_path')
+parser.add_argument('-o', '--output', help='replace this face', dest='output_file')
 parser.add_argument('--keep-fps', help='maintain original fps', dest='keep_fps', action='store_true', default=False)
 parser.add_argument('--gpu', help='use gpu', dest='gpu', action='store_true', default=False)
 parser.add_argument('--keep-frames', help='keep frames directory', dest='keep_frames', action='store_true', default=False)

--- a/run.py
+++ b/run.py
@@ -20,7 +20,7 @@ args = {}
 parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--face', help='use this face', dest='source_img')
 parser.add_argument('-t', '--target', help='replace this face', dest='target_path')
-parser.add_argument('-o', '--output', help='replace this face', dest='output_file')
+parser.add_argument('-o', '--output', help='save output to this file', dest='output_file')
 parser.add_argument('--keep-fps', help='maintain original fps', dest='keep_fps', action='store_true', default=False)
 parser.add_argument('--gpu', help='use gpu', dest='gpu', action='store_true', default=False)
 parser.add_argument('--keep-frames', help='keep frames directory', dest='keep_frames', action='store_true', default=False)


### PR DESCRIPTION
I tried running this from CLI using this syntax:

    python run.py -f mypic.jpg -t myvid.mp4

It runs almost until the end, but then fails at saving the file:

```
Traceback (most recent call last):
  File "/home/xxx/roop/run.py", line 98, in <module>
    start()
  File "/home/xxx/roop/run.py", line 91, in start
    add_audio(current_dir, output_dir, target_path, args['keep_frames'], args['output_file'])
KeyError: 'output_file'
```

I think this happens because there is no command line option to set `output_file`. I was assuming that the target video set using `-t` would be overwritten, but this does not happen.

This PR adds the `-o` or `--output` option. I can now run successfully with this command:

    python run.py -f mypic.jpg -t myvid.mp4 -o output.mp4