### PR TITLE
Skip processing if there is no face, print output to console

### DIFF
--- a/core/processor.py
+++ b/core/processor.py
@@ -23,7 +23,7 @@ def process_video(source_img, frame_paths):
         except Exception as e:
             print('E', end='', flush=True)
             pass
-
+    print(flush=True)
 
 def process_img(source_img, target_path):
     frame = cv2.imread(target_path)

--- a/core/processor.py
+++ b/core/processor.py
@@ -14,9 +14,14 @@ def process_video(source_img, frame_paths):
         frame = cv2.imread(frame_path)
         try:
             face = get_face(frame)
-            result = face_swapper.get(frame, face, source_face, paste_back=True)
-            cv2.imwrite(frame_path, result)
+            if face:
+                result = face_swapper.get(frame, face, source_face, paste_back=True)
+                cv2.imwrite(frame_path, result)
+                print('.', end='', flush=True)
+            else:
+                print('S', end='', flush=True)
         except Exception as e:
+            print('E', end='', flush=True)
             pass
 
 


### PR DESCRIPTION
It was the simples way to speed up **roop** by a ton, also added output to the console.

`.` ~ Processed
`S` ~ Skipped
`E` ~ Exception

## Preview

![Bildschirmfoto vom 2023-05-29 15-51-44](https://github.com/s0md3v/roop/assets/1835397/eb3380fb-b1e7-4468-99e9-c205faec206e)
