### PR TITLE
Fix: Resolved 'NameError: name 'status_label' is not defined' in status function for Client Mode

### DIFF
--- a/run.py
+++ b/run.py
@@ -128,9 +128,12 @@ def save_file():
 
 
 def status(string):
-    status_label["text"] = "Status: " + string
-    window.update()
-
+    if args['source_img']:
+        print("Status: " + string)
+    else:
+        status_label["text"] = "Status: " + string
+        window.update()
+        
 
 def start():
     print("DON'T WORRY. IT'S NOT STUCK/CRASHED.\n" * 5)


### PR DESCRIPTION
This pull request fixes the issue of encountering a "NameError: name 'status_label' is not defined" error in the status function when running in Client Mode. The problem has been resolved by adding a print statement specifically for Client Mode execution.