### PR TITLE
Changed output file path

### DIFF
--- a/run.py
+++ b/run.py
@@ -123,7 +123,10 @@ def toggle_keep_frames():
 
 
 def save_file():
-    args['output_file'] = asksaveasfilename(initialfile='output.mp4', defaultextension=".mp4", filetypes=[("All Files","*.*"),("Videos","*.mp4")])
+    # args['output_file'] = asksaveasfilename(initialfile='output.mp4', defaultextension=".mp4", filetypes=[("All Files","*.*"),("Videos","*.mp4")])
+    output_filename = 'output.mp4'
+    dir_name = os.path.dirname(args['target_path'])
+    args['output_file'] = os.path.join(dir_name, output_filename)
 
 
 def status(string):


### PR DESCRIPTION
The issue appears to stem from the 'output_file' being an empty string. The exact cause of this is uncertain, though it may be related to a bug in Tkinter. A potential interim solution is to modify the output directory. This approach has proven effective in resolving the issue on my end when using an M1 Monterey system.