### PR TITLE
Another split fix.

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -45,8 +45,8 @@ def extract_frames(input_path, output_dir):
 
 
 def add_audio(output_dir, target_path, keep_frames, output_file):
-    video = target_path.split("/")[-1]
-    video_name = video.split(".")[0]
+    video = os.path.basename(target_path)
+    video_name = os.path.splitext(video)[0]
     save_to = output_file if output_file else output_dir + f"/swapped-" + video_name + ".mp4"
     save_to_ff, output_dir_ff = path(save_to), path(output_dir)
     os.system(f'ffmpeg -i "{output_dir_ff}{sep}output.mp4" -i "{output_dir_ff}{sep}{video}" -c:v copy -map 0:v:0 -map 1:a:0 -y "{save_to_ff}"')


### PR DESCRIPTION
Actually, isn't the original just in target_path instead of `"{output_dir_ff}{sep}{video}"`?