### PR TITLE
fix TensorRTExcutionProvider errors

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -1,0 +1,7 @@
+import onnxruntime
+
+use_gpu = False
+providers = onnxruntime.get_available_providers()
+
+if 'TensorrtExecutionProvider' in providers:
+    providers.remove('TensorrtExecutionProvider')


### PR DESCRIPTION
Just For Windows Nvidia GPU User, the Provider returned by Program include tensorrtexcutionprovider, but the insightface default model don't surpport this.
but for nvidia user, The Command `onnxruntime.get_available_providers()` will return TensorrtExecutionProvider, TensorrtExecutionProvider will make memory leak.