### PR TITLE
fix: ffmpeg cmd line

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -36,7 +36,7 @@ def set_fps(input_path, output_path, fps):
 
 def create_video(video_name, fps, output_dir):
     output_dir = path(output_dir)
-    os.system(f'ffmpeg -framerate "{fps}" -i "{output_dir}{sep}%04d.png" -c:v libx264 -crf 7 -pix_fmt yuv420p -y "{output_dir}{sep}output.mp4"')
+    os.system(f'ffmpeg -framerate "{fps.strip()}" -i "{output_dir}{sep}%04d.png" -c:v libx264 -crf 7 -pix_fmt yuv420p -y "{output_dir}{sep}output.mp4"')
 
 
 def extract_frames(input_path, output_dir):


### PR DESCRIPTION
When the {fps} format is very strange (including line breaks), it will break the ffmpeg command line.

The output file and subsequent operations were interrupted, with an error `FileNotFoundError: [Errno 2] No such file or directory`