### PR TITLE
Add a processer bar with remain time for CLI

### DIFF
--- a/core/processor.py
+++ b/core/processor.py
@@ -1,9 +1,10 @@
 import os
-
+from tqdm import tqdm
 import cv2
 import insightface
 import core.globals
 from core.config import get_face
+from tqdm import tqdm
 
 FACE_SWAPPER = None
 
@@ -18,19 +19,21 @@ def get_face_swapper():
 
 def process_video(source_img, frame_paths):
     source_face = get_face(cv2.imread(source_img))
-    for frame_path in frame_paths:
-        frame = cv2.imread(frame_path)
-        try:
-            face = get_face(frame)
-            if face:
-                result = get_face_swapper().get(frame, face, source_face, paste_back=True)
-                cv2.imwrite(frame_path, result)
-                print('.', end='', flush=True)
-            else:
-                print('S', end='', flush=True)
-        except Exception:
-            print('E', end='', flush=True)
-            pass
+    with tqdm(total=len(frame_paths), desc="Processing", unit="frame", dynamic_ncols=True, bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}{postfix}]') as pbar:
+        for frame_path in frame_paths:
+            frame = cv2.imread(frame_path)
+            try:
+                face = get_face(frame)
+                if face:
+                    result = get_face_swapper().get(frame, face, source_face, paste_back=True)
+                    cv2.imwrite(frame_path, result)
+                    pbar.set_postfix(status='.', refresh=True)
+                else:
+                    pbar.set_postfix(status='S', refresh=True)
+            except Exception:
+                pbar.set_postfix(status='E', refresh=True)
+                pass
+            pbar.update(1)
 
 
 def process_img(source_img, target_path, output_file):

--- a/core/processor.py
+++ b/core/processor.py
@@ -4,7 +4,6 @@ import cv2
 import insightface
 import core.globals
 from core.config import get_face
-from tqdm import tqdm
 
 FACE_SWAPPER = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ torch==2.0.1
 onnxruntime-gpu==1.15.0
 opennsfw2==0.10.2
 protobuf==3.20.2
+tqdm==4.65.0


### PR DESCRIPTION
Add a processer bar with remain time for CLI
![image](https://github.com/s0md3v/roop/assets/28835093/85071e71-2f78-4501-a22c-86121c6b3771)
