### PR TITLE
all_faces fix / cancel and remember last paths for file dialogs 

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -172,7 +172,7 @@ def save_file():
     filename, ext = 'output.mp4', '.mp4'
     if is_img(args['target_path']):
         filename, ext = 'output.png', '.png'
-    file = asksaveasfilename(initialfile=filename, defaultextension=ext, filetypes=[("All Files","*.*"),("Videos","*.mp4")])
+    file = asksaveasfilename(initialfile=filename, initialdir=last_output_path_dir, defaultextension=ext, filetypes=[("All Files","*.*"),("Videos","*.mp4")])
     if file: 
         last_output_path_dir = os.path.dirname(file)
         args['output_file'] = file


### PR DESCRIPTION
* `all_faces` is always in args due to parser, defaults to False.. the original check was incorrect as it only checked it was present not True

* allow file dialog buttons to be cancelled, so processing does not continue

* store recent paths for each file dialog separately