### PR TITLE
Check for empty strings in image/video selections

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -223,8 +223,10 @@ def select_face_handler(path: str):
 
 
 def select_target_handler(path: str):
-    args.target_path = path
-    return preview_video(args.target_path)
+    if path and path != "":
+        args.target_path = path
+        return preview_video(args.target_path)
+    return 0
 
 
 def toggle_all_faces_handler(value: int):

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -90,8 +90,9 @@ def update_preview(frame):
 def select_face(select_face_handler: Callable[[str], None]):
     if select_face_handler:
         path = filedialog.askopenfilename(title="Select a face")
-        preview_face(path)
-        return select_face_handler(path)
+        if path and path != "":
+            preview_face(path)
+            return select_face_handler(path)
     return None
 
 


### PR DESCRIPTION
Prevents exception when Image/Video object is initialized with an empty string.