### PR TITLE
Fix add_audio() function

### DIFF
--- a/roop/utils.py
+++ b/roop/utils.py
@@ -53,8 +53,10 @@ def extract_frames(input_path, output_dir):
 
 
 def add_audio(output_dir, target_path, video, keep_frames, output_file):
-    video_name = os.path.splitext(video)[0]
-    save_to = output_file if output_file else output_dir + "/swapped-" + video_name + ".mp4"
+    video_name = os.path.basename(video)
+    save_to = output_file if output_file else output_dir + "/swapped-" + video_name
+    if '/output.mp4' in save_to:   
+        save_to = save_to.replace('output.mp4', '_output.mp4')
     save_to_ff, output_dir_ff = path(save_to), path(output_dir)
     run_ffmpeg(f'-i "{output_dir_ff}{sep}output.mp4" -i "{output_dir_ff}{sep}{video}" -c:v copy -map 0:v:0 -map 1:a:0 -y "{save_to_ff}"')
     if not os.path.isfile(save_to):


### PR DESCRIPTION
If the extension of the source video file is not "mp4", ffmpeg will not find the file. If the resulting file name = "output.mp4" (by default), then ffmpeg will not record sound to a file with the same name. This fix fixes these problems.