### PR TITLE
Aspect ratio fix for preview and miniatures

### DIFF
--- a/roop/ui.py
+++ b/roop/ui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from typing import Any, Callable, Tuple
-from PIL import Image, ImageTk
+from PIL import Image, ImageTk, ImageOps
 import webbrowser
 from tkinter import filedialog
 from tkinter.filedialog import asksaveasfilename
@@ -69,19 +69,7 @@ def init_slider(frames_count, change_handler):
 
 def update_preview(frame):
     img = Image.fromarray(frame)
-    width, height = img.size
-    aspect_ratio = 1
-    if width > height:
-        aspect_ratio = max_preview_size / width
-    else:
-        aspect_ratio = max_preview_size / height
-    img = img.resize(
-        (
-            int(width * aspect_ratio), 
-            int(height * aspect_ratio)
-        ), 
-        Image.ANTIALIAS
-    )
+    img = ImageOps.contain(img, (max_preview_size, max_preview_size), Image.LANCZOS)
     photo_img = ImageTk.PhotoImage(img)
     preview_image_frame.configure(image=photo_img)
     preview_image_frame.image = photo_img
@@ -211,7 +199,7 @@ def open_preview_window(get_video_frame, target_path):
 
 def preview_face(path):
     img = Image.open(path)
-    img = img.resize((180, 180), Image.ANTIALIAS)
+    img = ImageOps.contain(img, (180, 180), Image.LANCZOS)
     photo_img = ImageTk.PhotoImage(img)
     face_label.configure(image=photo_img)
     face_label.image = photo_img
@@ -219,7 +207,7 @@ def preview_face(path):
 
 def preview_target(frame):
     img = Image.fromarray(frame)
-    img = img.resize((180, 180), Image.ANTIALIAS)
+    img = ImageOps.contain(img, (180, 180), Image.LANCZOS)
     photo_img = ImageTk.PhotoImage(img)
     target_label.configure(image=photo_img)
     target_label.image = photo_img


### PR DESCRIPTION
Hi,

This small change improves the way the aspect ratio is maintained by using the ImageOps part of the PIL library.

The contain method automatically maintains aspect ratio: https://pillow.readthedocs.io/en/stable/reference/ImageOps.html#PIL.ImageOps.contain

I have applied the change to the preview image where the aspect ratio was calculated by hand, and also to the thumbnails for the source and target.