### PR TITLE
fix: wrong output_dir path under windows in CLI mode

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -184,14 +184,14 @@ def start(preview_callback = None):
     seconds, probabilities = predict_video_frames(video_path=args.target_path, frame_interval=100)
     if any(probability > 0.85 for probability in probabilities):
         quit()
-    video_name_full = target_path.split("/")[-1]
+    video_name_full = target_path.split(os.sep)[-1]
     video_name = os.path.splitext(video_name_full)[0]
-    output_dir = os.path.dirname(target_path) + "/" + video_name if os.path.dirname(target_path) else video_name
+    output_dir = os.path.join(os.path.dirname(target_path), video_name) if os.path.dirname(target_path) else video_name
     Path(output_dir).mkdir(exist_ok=True)
     status("detecting video's FPS...")
     fps, exact_fps = detect_fps(target_path)
     if not args.keep_fps and fps > 30:
-        this_path = output_dir + "/" + video_name + ".mp4"
+        this_path = os.path.join(output_dir, video_name, '.mp4')
         set_fps(target_path, this_path, 30)
         target_path, exact_fps = this_path, 30
     else:


### PR DESCRIPTION
There is a bug that occurs when the script is running in Windows CLI mode and the target path is passed with Windows delimiters (even if they are escaped, i.e., both for `\` and `\\`). In this case, the path for the folder containing the images will be generated incorrectly, resulting in a `WindowsError: [Error 123] The filename, directory name, or volume label syntax is incorrect` error.

For example:
`--target="d:\WORK\roop\data\some_video.mp4"` leads to the `output_dir` name `d:\WORK\roop\data\d:\WORK\roop\data\some_video` (when the expected path is `d:\WORK\roop\data\some_video`).

This PR fixes this bug.