### PR TITLE
Issue 376: hardware accelerated encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ options:
   --keep-audio          maintain original audio
   --keep-frames         keep frames directory
   --many-faces          swap every face in the frame
-  --video-encoder VIDEO_ENCODER
-                        adjust output video encoder
   --video-quality VIDEO_QUALITY
                         adjust output video quality
   --max-memory MAX_MEMORY

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ options:
                         number of threads to be use for the GPU
   --gpu-vendor {apple,amd,intel,nvidia}
                         choice your GPU vendor
+  --ffmpeg-encoder      ffmpeg encoder (see ffmpeg -encoders output). If the parameter is omitted, codec will match to --gpu-vendor.
 ```
 
 Looking for a CLI mode? Using the -f/--face argument will make the program in cli mode.

--- a/roop/core.py
+++ b/roop/core.py
@@ -47,6 +47,7 @@ def parse_args() -> None:
     parser.add_argument('--cpu-cores', help='number of CPU cores to use', dest='cpu_cores', type=int, default=max(psutil.cpu_count() / 2, 1))
     parser.add_argument('--gpu-threads', help='number of threads to be use for the GPU', dest='gpu_threads', type=int, default=8)
     parser.add_argument('--gpu-vendor', help='select your GPU vendor', dest='gpu_vendor', choices=['apple', 'amd', 'nvidia'])
+    parser.add_argument('--ffmpeg-encoder', help='select ffmpeg encoder', dest='ffmpeg_encoder')
 
     args = parser.parse_known_args()[0]
 
@@ -59,6 +60,7 @@ def parse_args() -> None:
     roop.globals.keep_frames = args.keep_frames
     roop.globals.many_faces = args.many_faces
     roop.globals.video_quality = args.video_quality
+    roop.globals.ffmpeg_encoder = args.ffmpeg_encoder
 
     if args.cpu_cores:
         roop.globals.cpu_cores = int(args.cpu_cores)

--- a/roop/core.py
+++ b/roop/core.py
@@ -42,7 +42,6 @@ def parse_args() -> None:
     parser.add_argument('--keep-audio', help='maintain original audio', dest='keep_audio', action='store_true', default=True)
     parser.add_argument('--keep-frames', help='keep frames directory', dest='keep_frames', action='store_true', default=False)
     parser.add_argument('--many-faces', help='swap every face in the frame', dest='many_faces', action='store_true', default=False)
-    parser.add_argument('--video-encoder', help='adjust output video encoder', dest='video_encoder', default='libx264')
     parser.add_argument('--video-quality', help='adjust output video quality', dest='video_quality', type=int, default=10)
     parser.add_argument('--max-memory', help='maximum amount of RAM in GB to be used', dest='max_memory', type=int)
     parser.add_argument('--cpu-cores', help='number of CPU cores to use', dest='cpu_cores', type=int, default=max(psutil.cpu_count() / 2, 1))
@@ -60,7 +59,6 @@ def parse_args() -> None:
     roop.globals.keep_audio = args.keep_audio
     roop.globals.keep_frames = args.keep_frames
     roop.globals.many_faces = args.many_faces
-    roop.globals.video_encoder = args.video_encoder
     roop.globals.video_quality = args.video_quality
     roop.globals.ffmpeg_encoder = args.ffmpeg_encoder
 

--- a/roop/globals.py
+++ b/roop/globals.py
@@ -13,8 +13,16 @@ gpu_threads = None
 gpu_vendor = None
 max_memory = None
 headless = None
+ffmpeg_encoder = None
 log_level = 'error'
 providers = onnxruntime.get_available_providers()
 
 if 'TensorrtExecutionProvider' in providers:
     providers.remove('TensorrtExecutionProvider')
+
+list_encoders = {
+    'nvidia': 'h264_nvenc',
+    'amd': 'h264_amf',
+    'apple': 'h264_videotoolbox',
+    'intel': 'h264_qsv'
+}

--- a/roop/globals.py
+++ b/roop/globals.py
@@ -7,7 +7,6 @@ keep_fps = None
 keep_audio = None
 keep_frames = None
 many_faces = None
-video_encoder = None
 video_quality = None
 cpu_cores = None
 gpu_threads = None

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -35,7 +35,8 @@ def extract_frames(target_path: str) -> None:
 
 
 def create_video(target_path: str, fps: int) -> None:
-    run_ffmpeg(['-i', get_temp_directory_path(target_path) + os.sep + '%04d.png', '-framerate', str(fps), '-c:v', 'libx264', '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', get_temp_file_path(target_path)])
+    encoder = roop.globals.list_encoders.get(roop.globals.gpu_vendor, 'libx264') if roop.globals.ffmpeg_encoder is None else roop.globals.ffmpeg_encoder
+    run_ffmpeg(['-i', get_temp_directory_path(target_path) + os.sep + '%04d.png', '-framerate', str(fps), '-c:v', encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', get_temp_file_path(target_path)])
 
 
 def restore_audio(target_path: str, output_path: str) -> None:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -37,7 +37,6 @@ def extract_frames(target_path: str) -> None:
 def create_video(target_path: str, fps: int) -> None:
     encoder = roop.globals.list_encoders.get(roop.globals.gpu_vendor, 'libx264') if roop.globals.ffmpeg_encoder is None else roop.globals.ffmpeg_encoder
     run_ffmpeg(['-i', get_temp_directory_path(target_path) + os.sep + '%04d.png', '-framerate', str(fps), '-c:v', encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', get_temp_file_path(target_path)])
-    run_ffmpeg(['-i', get_temp_directory_path(target_path) + os.sep + '%04d.png', '-framerate', str(fps), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', get_temp_file_path(target_path)])
 
 
 def restore_audio(target_path: str, output_path: str) -> None:


### PR DESCRIPTION
#376 

The ability to select a ffmpeg encoder has been added via `--ffmpeg-encoder` parameter. If the codec is not specified, a binding to the `--gpu-vendor` will be used. If both parameters are skipped, `libx264` encoder will be used as before.