### PR TITLE
Draft: nvidia-enabled Docker container and scripting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .idea
 __pycache__
-*.onnx
 .env
 .envrc
 .tool-versions

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,77 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+ARG DEFAULT_UID=1000
+ARG DEFAULT_GID=1000
+ENV DEFAULT_UID $DEFAULT_UID
+ENV DEFAULT_GID $DEFAULT_GID
+ENV PUSER "rooper"
+ENV PGROUP "rooper"
+ENV PUSER_PRIV_DROP true
+ENV PUSER_RLIMIT_UNLOCK true
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+
+ENV BUFFALO_L_URL "https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_l.zip"
+# ENV INSWAPPER_128_URL "https://1drv.ms/u/s!AsHA3Xbnj6uAgxhb_tmQ7egHACOR?e=CPoThO"
+
+COPY --chmod=644 ./inswapper_128.onnx /roop/inswapper_128.onnx
+COPY ./requirements.txt /tmp/requirements.txt
+
+RUN apt-get -q update && \
+    apt-get install -q -y --no-install-recommends \
+        build-essential \
+        curl \
+        ffmpeg \
+        procps \
+        psmisc \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-tk \
+        python3-wheel \
+        sudo \
+        tini \
+        unzip \
+        vim-tiny \
+        zlib1g && \
+    sed -i "s/set[[:space:]]*compatible/set nocompatible/g" /etc/vim/vimrc.tiny && \
+    groupadd --gid ${DEFAULT_GID} ${PGROUP} && \
+      useradd -m --uid ${DEFAULT_UID} --gid ${DEFAULT_GID} --home /home/${PUSER} ${PUSER} && \
+      usermod -a -G tty ${PUSER} && \
+      chsh -s /bin/bash ${PUSER} && \
+      usermod -a -G sudo ${PUSER} && \
+      echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    python3 -m pip install --index-url https://download.pytorch.org/whl/cu118 torch torchvision torchaudio && \
+        python3 -m pip install onnxruntime-gpu && \
+        python3 -m pip install -r /tmp/requirements.txt && \
+    ln -s -r /usr/local/cuda-11.8/targets/x86_64-linux/lib/libnvrtc.so.11.2 /usr/local/cuda-11.8/targets/x86_64-linux/lib/libnvrtc.so.11 && \
+        ln -s -r /usr/local/cuda-11.8/targets/x86_64-linux/lib/libnvrtc.so.11 /usr/local/cuda-11.8/targets/x86_64-linux/lib/libnvrtc.so && \
+    mkdir -p /roop/roop /home/${PUSER}/.insightface/models/buffalo_l && \
+        # curl -fsSL -o /roop/inswapper_128.onnx "${INSWAPPER_128_URL}" && \
+        curl -fsSL -o /tmp/buffalo_l.zip "${BUFFALO_L_URL}" && \
+        ln -s -r /roop/inswapper_128.onnx /roop/roopVideoFace_v10.onnx && \
+        cd /home/${PUSER}/.insightface/models/buffalo_l && \
+        unzip /tmp/buffalo_l.zip -d /home/${PUSER}/.insightface/models/buffalo_l && \
+    chown -R ${PUSER}:${PGROUP} /home/${PUSER} /roop && \
+    apt-get -y -q --allow-downgrades --allow-remove-essential --allow-change-held-packages --purge remove \
+        build-essential \
+        curl \
+        python3-dev \
+        unzip && \
+    apt-get -y -q --allow-downgrades --allow-remove-essential --allow-change-held-packages autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --chmod=755 ./*.py /roop/
+COPY --chmod=755 ./roop/*.py /roop/roop
+COPY --chmod=755 ./docker/docker-uid-gid-setup.sh /usr/local/bin/docker-uid-gid-setup.sh
+
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
+
+WORKDIR /roop
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-uid-gid-setup.sh"]

--- a/docker/build_roop_docker.sh
+++ b/docker/build_roop_docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+ENCODING="utf-8"
+
+# image name (can be overriden via ROOP_IMAGE env. var.)
+ROOP_IMAGE="${ROOP_IMAGE:-roop:latest}"
+# container engine (docker vs. podman, can be overriden via CONTAINER_ENGINE env. var.)
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
+
+[[ "$(uname -s)" = 'Darwin' ]] && REALPATH=grealpath || REALPATH=realpath
+[[ "$(uname -s)" = 'Darwin' ]] && DIRNAME=gdirname || DIRNAME=dirname
+if ! (type "$REALPATH" && type "$DIRNAME" && type $CONTAINER_ENGINE) > /dev/null; then
+  echo "$(basename "${BASH_SOURCE[0]}") requires $CONTAINER_ENGINE, $REALPATH and $DIRNAME"
+  exit 1
+fi
+export SCRIPT_PATH="$($DIRNAME $($REALPATH -e "${BASH_SOURCE[0]}"))"
+
+pushd "$SCRIPT_PATH"/.. >/dev/null 2>&1
+
+$CONTAINER_ENGINE build -f docker/Dockerfile -t "$ROOP_IMAGE" "$@" .
+
+popd >/dev/null 2>&1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+
+services:
+  roop:
+    image: roop:latest
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    restart: no
+    env_file:
+      - .env
+    command: nvidia-smi
+    runtime: nvidia
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [compute, utility, video]

--- a/docker/docker-uid-gid-setup.sh
+++ b/docker/docker-uid-gid-setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# attempt to set ulimits (as root)
+if [[ "${PUSER_RLIMIT_UNLOCK:-false}" == "true" ]] && command -v ulimit >/dev/null 2>&1; then
+  ulimit -c 0 >/dev/null 2>&1
+  ulimit -l unlimited >/dev/null 2>&1
+  ulimit -m unlimited >/dev/null 2>&1
+  ulimit -v unlimited >/dev/null 2>&1
+  ulimit -x unlimited >/dev/null 2>&1
+  ulimit -n 65535 >/dev/null 2>&1
+  ulimit -u 262144 >/dev/null 2>&1
+fi
+
+unset ENTRYPOINT_CMD
+unset ENTRYPOINT_ARGS
+[ "$#" -ge 1 ] && ENTRYPOINT_CMD="$1" && [ "$#" -gt 1 ] && shift 1 && ENTRYPOINT_ARGS=( "$@" )
+
+# modify the UID/GID for the default user/group (for example, 1000 -> 1001)
+usermod --non-unique --uid ${PUID:-${DEFAULT_UID}} ${PUSER}
+groupmod --non-unique --gid ${PGID:-${DEFAULT_GID}} ${PGROUP}
+
+# change user/group ownership of any files/directories belonging to the original IDs
+if [[ -n ${PUID} ]] && [[ "${PUID}" != "${DEFAULT_UID}" ]]; then
+  find / -path /sys -prune -o -path /proc -prune -o -user ${DEFAULT_UID} -exec chown -f ${PUID} "{}" \; 2>/dev/null
+fi
+if [[ -n ${PGID} ]] && [[ "${PGID}" != "${DEFAULT_GID}" ]]; then
+  find / -path /sys -prune -o -path /proc -prune -o -group ${DEFAULT_GID} -exec chown -f :${PGID} "{}" \; 2>/dev/null
+fi
+
+# if there are semicolon-separated PUSER_CHOWN entries explicitly specified, chown them too
+if [[ -n ${PUSER_CHOWN} ]]; then
+  IFS=';' read -ra ENTITIES <<< "${PUSER_CHOWN}"
+  for ENTITY in "${ENTITIES[@]}"; do
+    chown -R ${PUSER}:${PGROUP} "${ENTITY}" 2>/dev/null
+  done
+fi
+
+# determine if we are now dropping privileges to exec ENTRYPOINT_CMD
+if [[ "$PUSER_PRIV_DROP" == "true" ]]; then
+  EXEC_USER="${PUSER}"
+  USER_HOME="$(getent passwd ${PUSER} | cut -d: -f6)"
+else
+  EXEC_USER="${USER:-root}"
+  USER_HOME="${HOME:-/root}"
+fi
+
+# attempt to set ulimits (as user) and execute the entrypoint command specified
+su -s /bin/bash -p ${EXEC_USER} << EOF
+export USER="${EXEC_USER}"
+export HOME="${USER_HOME}"
+whoami
+id
+if [[ "${PUSER_RLIMIT_UNLOCK:-false}" == "true" ]] && command -v ulimit >/dev/null 2>&1; then
+  ulimit -c 0 >/dev/null 2>&1
+  ulimit -l unlimited >/dev/null 2>&1
+  ulimit -m unlimited >/dev/null 2>&1
+  ulimit -v unlimited >/dev/null 2>&1
+  ulimit -x unlimited >/dev/null 2>&1
+  ulimit -n 65535 >/dev/null 2>&1
+  ulimit -u 262144 >/dev/null 2>&1
+fi
+if [[ ! -z "${ENTRYPOINT_CMD}" ]]; then
+  if [[ -z "${ENTRYPOINT_ARGS}" ]]; then
+    "${ENTRYPOINT_CMD}"
+  else
+    "${ENTRYPOINT_CMD}" $(printf "%q " "${ENTRYPOINT_ARGS[@]}")
+  fi
+fi
+EOF

--- a/docker/roop-docker.sh
+++ b/docker/roop-docker.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# wrapper shell script for roop in a docker image
+# eg.,
+# roop-docker.sh -r nvidia -f ~/tmp/face.jpg -t ~/tmp/target.mp4 -o ~/tmp/outdocker.mp4 -- --gpu-vendor=nvidia --gpu-threads=2 --keep-frames
+
+set -o pipefail
+set -u
+
+ENCODING="utf-8"
+
+[[ "$(uname -s)" = 'Darwin' ]] && REALPATH=grealpath || REALPATH=realpath
+[[ "$(uname -s)" = 'Darwin' ]] && DIRNAME=gdirname || DIRNAME=dirname
+if ! (type "$REALPATH" && type "$DIRNAME" && type $CONTAINER_ENGINE) > /dev/null; then
+  echo "$(basename "${BASH_SOURCE[0]}") requires $CONTAINER_ENGINE, $REALPATH and $DIRNAME" >&2
+  exit 1
+fi
+SCRIPT_PATH="$($DIRNAME $($REALPATH -e "${BASH_SOURCE[0]}"))"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+VERBOSE_FLAG=
+FACE=
+TARGET=
+OUTPUT=
+ROOP_IMAGE="${ROOP_IMAGE:-roop:latest}"
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
+RUNTIME_ARGS=()
+while getopts 'vf:t:o:i:e:r:' OPTION; do
+  case "$OPTION" in
+    v)
+      set -x
+      VERBOSE_FLAG="-v"
+      ;;
+
+    f)
+      FACE="$OPTARG"
+      ;;
+
+    t)
+      TARGET="$OPTARG"
+      ;;
+
+    o)
+      OUTPUT="$OPTARG"
+      ;;
+
+    i)
+      ROOP_IMAGE="$OPTARG"
+      ;;
+
+    e)
+      CONTAINER_ENGINE="$OPTARG"
+      ;;
+
+    r)
+      RUNTIME_ARGS+=( --runtime )
+      RUNTIME_ARGS+=( "$OPTARG" )
+      ;;
+
+    ?)
+      echo "script usage: $(basename $0) [-f face] [-t target] [-o output] (-i <roop image>) (-e <container engine>) (-r <container runtime>)" >&2
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND -1))"
+ROOP_RUN_ARGS=("$@")
+
+PUID=$([[ "${CONTAINER_ENGINE}" == "podman" ]] && echo 0 || id -u)
+PGID=$([[ "${CONTAINER_ENGINE}" == "podman" ]] && echo 0 || id -g)
+
+TEMP_DIR=$(mktemp -d -p "$($DIRNAME "${OUTPUT}")" -t roop.XXXXXXXXXX)
+FACE_BASENAME="$(basename "${FACE}")"
+TARGET_BASENAME="$(basename "${TARGET}")"
+OUT_BASENAME="$(basename "${OUTPUT}")"
+
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+function finish {
+  if containsElement "--keep-frames" "${ROOP_RUN_ARGS[@]}"; then
+    rm $VERBOSE_FLAG -f "${TEMP_DIR}/${FACE_BASENAME}" "${TEMP_DIR}/${TARGET_BASENAME}" "${TEMP_DIR}/${OUT_BASENAME}"
+    mv $VERBOSE_FLAG "${TEMP_DIR}"/* "${TEMP_DIR}"/../
+    rmdir "${TEMP_DIR}"
+  else
+    rm $VERBOSE_FLAG -rf "${TEMP_DIR}"
+  fi
+}
+trap finish EXIT
+
+cp $VERBOSE_FLAG "${FACE}" "${TEMP_DIR}/"
+cp $VERBOSE_FLAG "${TARGET}" "${TEMP_DIR}/"
+
+"${CONTAINER_ENGINE}" run --rm -t \
+  "${RUNTIME_ARGS[@]}" \
+  -e PUID=$PUID \
+  -e PGID=$PGID \
+  -v "${TEMP_DIR}:/data:rw" \
+  -w "/data" \
+  "${ROOP_IMAGE}" \
+  python3 /roop/run.py \
+  -f "/data/${FACE_BASENAME}" \
+  -t "/data/${TARGET_BASENAME}" \
+  -o "/data/${OUT_BASENAME}" \
+  "${ROOP_RUN_ARGS[@]}"
+
+cp $VERBOSE_FLAG "${TEMP_DIR}/${OUT_BASENAME}" "${OUTPUT}"
+
+echo "${OUTPUT}"


### PR DESCRIPTION
related to s0md3v/roop#171

Adds `docker` directory to source tree containing:

* `Dockerfile` - defining the Docker container based on `nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04`
* `docker-compose.yml` - mainly just for testing as it prints out the output of `nvidia-smi` and that's it
* `build_roop_docker.sh` - convenience script for building the image
* `docker-uid-gid-setup.sh` - entrypoint for dropping privs from root to non-root UID
* `roop-docker.sh` - wrapper script for `docker run` to massage and pass some of the commands through

My Linux host environment has the NVIDIA driver and NVIDIA [container runtime](https://developer.nvidia.com/nvidia-container-runtime). I build the image and run my wrapper script like this:

```bash
$ ./docker/build_roop_docker.sh 
[+] Building 2.8s (13/13) FINISHED                                                                                                                                                             
 => [internal] load .dockerignore                                                                                                                                                         0.0s
 => => transferring context: 85B                                                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                      0.0s
 => => transferring dockerfile: 3.18kB                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04                                                                                                  1.3s
 => [internal] load build context                                                                                                                                                         0.0s
 => => transferring context: 13.31kB                                                                                                                                                      0.0s
 => [1/8] FROM docker.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04@sha256:334145928724f859d419359ce35dc77aac99c6ea8590ddcb5e52eb6a532ac963                                            0.0s
 => CACHED [2/8] COPY --chmod=644 ./inswapper_128.onnx /roop/inswapper_128.onnx                                                                                                           0.0s
 => CACHED [3/8] COPY ./requirements.txt /tmp/requirements.txt                                                                                                                            0.0s
 => CACHED [4/8] RUN apt-get -q update &&     apt-get install -q -y --no-install-recommends         build-essential         curl         ffmpeg         procps         psmisc         py  0.0s
 => CACHED [5/8] COPY --chmod=755 ./*.py /roop/                                                                                                                                           0.0s
 => [6/8] COPY --chmod=755 ./roop/*.py /roop/roop                                                                                                                                         0.0s
 => [7/8] COPY --chmod=755 ./docker/docker-uid-gid-setup.sh /usr/local/bin/docker-uid-gid-setup.sh                                                                                        0.0s
 => [8/8] WORKDIR /roop                                                                                                                                                                   0.0s
 => exporting to image                                                                                                                                                                    1.4s
 => => exporting layers                                                                                                                                                                   1.4s
 => => writing image sha256:c374d267a287da96c78a8984046390b655b8d3e5f8de8e1445ec7138516201ad                                                                                              0.0s
 => => naming to docker.io/library/roop:latest         

$ ./docker/roop-docker.sh -r nvidia -f ~/tmp/face.jpg -t ~/tmp/target.mp4 -o ~/tmp/outdocker.mp4 -- --gpu-vendor=nvidia --gpu-threads=2
rooper
uid=1001(rooper) gid=1001(rooper) groups=1001(rooper),5(tty),27(sudo)
...
Applied providers: ['CUDAExecutionProvider', 'CPUExecutionProvider'], ...
...
Video saved as: /data/outdocker.mp4 

Status: swap successful!
/home/user/tmp/outdocker.mp4
```

If this is useful to you, even as starting point, feel free to pull and adjust as you see fit. Or if you don't want to accept it feel free to close, no problem either way.