### PR TITLE
Run in Docker with Nvidia GPU

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.insightface
+.git
+*.jpg
+*.mp4
+*.onnx

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,44 @@
+# Running roop in Docker
+
+This is tested on a Linux host with an Nvidia GPU.
+
+## Prerequisites on the host
+
+1. Install Nvidia drivers:
+    a) Install automatically:
+        ```
+        ubuntu-drivers autoinstall
+        ```
+    b) Install specific version:
+        ```
+        apt install nvidia-driver-530
+        ```
+2. Install and enable Nvidia Container Toolkit:
+```
+apt install nvidia-docker2
+nvidia-ctk runtime configure
+systemctl restart docker
+```
+3. Test if GPU works in the container:
+```
+docker run --rm --runtime=nvidia --gpus all nvidia/cuda:11.8.0-base-ubuntu22.04 nvidia-smi
+```
+
+## Building the image
+
+1. Build the Docker image:
+```
+docker-compose build
+```
+2. Test if GPU works in the container:
+```
+docker-compose run roop nvidia-smi
+```
+
+## Usage
+
+Run roop in Docker:
+
+```
+docker-compose run roop python run.py --gpu-threads=1 --gpu-vendor=nvidia -f '/app/.github/examples/face.jpg' -t '/app/.github/examples/target.mp4' -o '/app/demo.mp4'
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+	ffmpeg \
+	nvidia-cudnn \
+	python3 \
+	python3-pip \
+	python3-tk \
+	python-is-python3
+
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+
+RUN mkdir -p /.config/matplotlib /.cache/matplotlib /.opennsfw2 && \
+	chown -R 1000 /.config /.cache /.opennsfw2
+
+CMD /bin/bash
+
+WORKDIR /app
+USER 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  roop:
+    build: .
+    volumes:
+      - .:/app
+      - .insightface:/.insightface
+    user: 1000:1000
+    deploy:
+     resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 
-numpy==1.23.5
 opencv-python==4.7.0.72
 onnx==1.14.0
 insightface==0.7.3
@@ -12,7 +11,7 @@ onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'
 onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.15.0; sys_platform != 'darwin'
 tensorflow==2.13.0rc1; sys_platform == 'darwin'
-tensorflow==2.12.0; sys_platform != 'darwin'
+tensorflow==2.13.0rc1; sys_platform != 'darwin'
 opennsfw2==0.10.2
 protobuf==4.23.2
 tqdm==4.65.0


### PR DESCRIPTION
I got roop working in Docker with Nvidia GPU while trying to keep the setup minimalistic.

Some notes:

- roop source code is not part of the image, it is mounted as a docker volume at runtime.
- The Docker image is based on Nvidia CUDA image, because that was the most tricky part to get working. However, the image should work with both Nvidia GPU and CPU engines.

Any feedback is welcome! I am ready to do some work to get this pull request merged.