### PR TITLE
Updated requirements.txt for macs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ insightface==0.7.3
 psutil==5.9.5
 tk==0.1.0
 pillow==9.5.0
-torch==2.0.1+cu118
+torch==2.0.1+cu118; sys_platform != 'darwin'
+torch==2.0.1; sys_platform == 'darwin'
 onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'
 onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.15.0; sys_platform != 'darwin'


### PR DESCRIPTION
There is no torch==2.0.1+cu118 for mac architecture, set to 2.0.1 for mac.