### PR TITLE
Run roop using docker-compose with Git clone

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.11
+FROM python:3.10
 
 RUN apt-get update && apt-get install -y \
 	ffmpeg
 
-RUN git clone https://github.com/s0md3v/roop.git /app
+RUN git clone https://github.com/s0md3v/roop.git /roop
 
-RUN cd /app && pip install -r requirements.txt
+RUN pip install -r roop/requirements.txt
 
-ENTRYPOINT ["python", "/app/run.py"]
+ENTRYPOINT ["python", "/roop/run.py"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11
+
+RUN apt-get update && apt-get install -y \
+	ffmpeg
+
+RUN git clone https://github.com/s0md3v/roop.git /app
+
+RUN cd /app && pip install -r requirements.txt
+
+ENTRYPOINT ["python", "/app/run.py"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,25 @@
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+	ffmpeg \
+	nvidia-cudnn \
+	python3 \
+	python3-pip \
+	python3-tk \
+	python-is-python3
+
+WORKDIR /app
+
+ADD requirements.txt .
+RUN pip install -r requirements.txt
+
+ADD inswapper_128.onnx .
+ADD run.py .
+ADD roop roop
+
+ENV HOME=/cache
+
+RUN mkdir /cache
+
+ENTRYPOINT ["python", "/app/run.py"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -3,23 +3,15 @@ FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
 	ffmpeg \
+	git \
 	nvidia-cudnn \
 	python3 \
 	python3-pip \
 	python3-tk \
 	python-is-python3
 
-WORKDIR /app
+RUN git clone https://github.com/s0md3v/roop.git /roop
 
-ADD requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r roop/requirements.txt
 
-ADD inswapper_128.onnx .
-ADD run.py .
-ADD roop roop
-
-ENV HOME=/cache
-
-RUN mkdir /cache
-
-ENTRYPOINT ["python", "/app/run.py"]
+ENTRYPOINT ["python", "/roop/run.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,4 +18,4 @@ services:
         devices:
           - driver: nvidia
             count: 1
-            capabilities: [gpu,video]
+            capabilities: [gpu, video]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  roop: &base
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ./roop/output:/home/node/roop/output
+      - ./roop/temp:/home/node/roop/temp
+    user: 1000:1000
+  roop-cuda:
+    <<: *base
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cuda
+    deploy:
+     resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: 1
+            capabilities: [gpu,video]


### PR DESCRIPTION
I tried to address all the issues from https://github.com/s0md3v/roop/pull/404
This pull request should be as close to your requirements as possible.

It doesn't work though, because `requirements.txt` needs to be fixed first:
```
INFO: pip is looking at multiple versions of onnxruntime-gpu to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 14), -r requirements.txt (line 4), -r requirements.txt (line 5), -r requirements.txt (line 6) and numpy==1.23.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.23.5
    opencv-python 4.7.0.72 depends on numpy>=1.21.2; python_version >= "3.10"
    opencv-python 4.7.0.72 depends on numpy>=1.22.0; python_version >= "3.11"
    opencv-python 4.7.0.72 depends on numpy>=1.17.0; python_version >= "3.7"
    opencv-python 4.7.0.72 depends on numpy>=1.17.3; python_version >= "3.8"
    opencv-python 4.7.0.72 depends on numpy>=1.19.3; python_version >= "3.9"
    onnx 1.14.0 depends on numpy
    insightface 0.7.3 depends on numpy
    onnxruntime-gpu 1.15.0 depends on numpy>=1.24.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
The command '/bin/sh -c cd /app && pip install -r requirements.txt' returned a non-zero code: 1
ERROR: Service 'roop' failed to build : Build failed
```