### PR TITLE
Fix images scaling

### DIFF
--- a/roop/ui.py
+++ b/roop/ui.py
@@ -32,6 +32,7 @@ def init(start: Callable, destroy: Callable) -> ctk.CTk:
 def create_root(start: Callable, destroy: Callable) -> ctk.CTk:
     global source_label, target_label, status_label
 
+    ctk.deactivate_automatic_dpi_awareness()
     ctk.set_appearance_mode('system')
     ctk.set_default_color_theme(resolve_relative_path('ui.json'))
     root = ctk.CTk()


### PR DESCRIPTION
Fix scaling on monitors with different resolutions. Old view:
![image](https://github.com/s0md3v/roop/assets/13403439/60d9bc67-ef59-4612-b797-526384b06dad)
4k (left) vs 1080p (right)