### PR TITLE
Fixed wrong frame colors for preview

### DIFF
--- a/roop/capturer.py
+++ b/roop/capturer.py
@@ -9,7 +9,7 @@ def get_video_frame(video_path: str, frame_number: int = 0) -> Any:
     has_frame, frame = capture.read()
     capture.release()
     if has_frame:
-        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return frame
     return None
 
 

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -208,7 +208,7 @@ def update_preview(frame_number: int = 0) -> None:
             get_one_face(cv2.imread(roop.globals.source_path)),
             get_video_frame(roop.globals.target_path, frame_number)
         )
-        image = Image.fromarray(video_frame)
+        image = Image.fromarray(cv2.cvtColor(video_frame, cv2.COLOR_BGR2RGB))
         image = ImageOps.contain(image, (PREVIEW_MAX_WIDTH, PREVIEW_MAX_HEIGHT), Image.LANCZOS)
         image = ImageTk.PhotoImage(image)
         preview_label.configure(image=image)


### PR DESCRIPTION
Colors correction must be done after all faces process in preview window.
![image](https://github.com/s0md3v/roop/assets/13403439/d9da59bb-7102-4b38-a66a-e8e8473a5086)
![image](https://github.com/s0md3v/roop/assets/13403439/c9473c44-fed6-4e9b-807b-89fff6f05bce)
Check eyes and eyebrows colors before and after.


