### PR TITLE
relocate some models weights to "models/" folder

### DIFF
--- a/roop/analyser.py
+++ b/roop/analyser.py
@@ -1,6 +1,7 @@
 from typing import Any
 import insightface
 import roop.globals
+from roop.utilities import resolve_relative_path
 
 FACE_ANALYSER = None
 
@@ -9,7 +10,12 @@ def get_face_analyser() -> Any:
     global FACE_ANALYSER
 
     if FACE_ANALYSER is None:
-        FACE_ANALYSER = insightface.app.FaceAnalysis(name='buffalo_l', providers=roop.globals.execution_providers)
+        FACE_ANALYSER = insightface.app.FaceAnalysis(
+            name='buffalo_l',
+            providers=roop.globals.execution_providers,
+            root=resolve_relative_path('..') # not '../models' because insightface auto create 'models/'
+            # url: https://github.com/deepinsight/insightface/releases/download/v0.7/buffalo_l.zip
+        )
         FACE_ANALYSER.prepare(ctx_id=0, det_size=(640, 640))
     return FACE_ANALYSER
 

--- a/roop/enhancer.py
+++ b/roop/enhancer.py
@@ -20,6 +20,9 @@ THREAD_LOCK = threading.Lock()
 def pre_check() -> None:
     download_directory_path = resolve_relative_path('../models')
     conditional_download(download_directory_path, ['https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/codeformer.pth'])
+    # 'https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/detection_Resnet50_Final.pth',
+    # 'https://github.com/sczhou/CodeFormer/releases/download/v0.1.0/parsing_parsenet.pth'
+    # detection & parsenet is downloaded when init FaceRestoreHelper, but cannot change download folder
 
 
 def get_code_former():
@@ -43,14 +46,14 @@ def get_code_former():
 def get_face_enhancer(FACE_ENHANCER):
     if FACE_ENHANCER is None:
         FACE_ENHANCER = FaceRestoreHelper(
-        upscale_factor = int(2),
-        face_size=512,
-        crop_ratio=(1, 1),
-        det_model='retinaface_resnet50',
-        save_ext='png',
-        use_parse=True,
-        device='cuda',
-    )
+            upscale_factor = int(2),
+            face_size=512,
+            crop_ratio=(1, 1),
+            det_model='retinaface_resnet50',
+            save_ext='png',
+            use_parse=True,
+            device='cuda',
+        )
     return FACE_ENHANCER
 
 

--- a/roop/swapper.py
+++ b/roop/swapper.py
@@ -15,6 +15,7 @@ THREAD_LOCK = threading.Lock()
 def pre_check() -> None:
     download_directory_path = resolve_relative_path('../models')
     conditional_download(download_directory_path, ['https://huggingface.co/deepinsight/inswapper/resolve/main/inswapper_128.onnx'])
+    # side-note: this huggingface account isn't owned by insightface, see: https://github.com/deepinsight/insightface/issues/2339
 
 
 def get_face_swapper() -> None:


### PR DESCRIPTION
commit d5228b8208e2dbab98e53dc6dee98c0239e2e156 introduce `models/` folder to put 'codeformer' and 'insightface inswappers' models weights, this PR would also relocate 'insightface buffalo' and 'opennsfw2' models weights

the aim is to easily locate and re-download in case of corrupted files (simply delete corrupted files and rerun to download again)

1/ insightface buffalo

previously located in `~/.insightface`

ref: https://github.com/deepinsight/insightface/blob/master/python-package/insightface/app/face_analysis.py

2/ opennsfw2

previously located in `~/.opennsfw2`

ref: https://github.com/bhky/opennsfw2/blob/main/opennsfw2/_download.py

---

[unsuccessfully relocate]

CodeFormer `FaceRestoreHelper` load 2 submodels `detection_Resnet50` and `parsing_parsenet`, their weights are downloaded to `<codeformer path>/weights/facelib`

impossible to change this path

refs:
https://github.com/sczhou/CodeFormer/blob/master/facelib/utils/face_restoration_helper.py
https://github.com/sczhou/CodeFormer/blob/master/facelib/detection/__init__.py
https://github.com/sczhou/CodeFormer/blob/master/facelib/parsing/__init__.py