### PR TITLE
Handling of dirs provided to the -o arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 models
 temp
 __pycache__
+inswapper_128.onnx

--- a/roop/core.py
+++ b/roop/core.py
@@ -22,7 +22,7 @@ import cv2
 import roop.globals
 import roop.ui as ui
 from roop.processors.frame.core import get_frame_processors_modules
-from roop.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp
+from roop.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, validate_output_path
 from roop.face_analyser import get_one_face
 
 if 'ROCMExecutionProvider' in roop.globals.execution_providers:
@@ -64,6 +64,8 @@ def parse_args() -> None:
     roop.globals.max_memory = args.max_memory
     roop.globals.execution_providers = decode_execution_providers(args.execution_provider)
     roop.globals.execution_threads = args.execution_threads
+
+    roop.globals.output_path = validate_output_path(roop.globals.target_path, roop.globals.output_path)
 
     # limit face enhancer to cuda
     if 'CUDAExecutionProvider' not in roop.globals.execution_providers and 'face_enhancer' in roop.globals.frame_processors:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -128,3 +128,14 @@ def conditional_download(download_directory_path: str, urls: List[str]):
 
 def resolve_relative_path(path: str) -> str:
     return os.path.abspath(os.path.join(os.path.dirname(__file__), path))
+
+def validate_output_path(target_path: str, output_path: str) -> str:
+    """
+    Checks if output_path is a directory or a file.
+    If it is a directory, it appends the filename from target_path to output_path.
+    If it is a file, it returns output_path as is.
+    """
+    if os.path.isdir(output_path):
+        return os.path.join(output_path, os.path.basename(target_path))
+    else:
+        return output_path


### PR DESCRIPTION
This tripped me up for a long time. It didn't provide any sort of error when passing as directory as the -o argument, and the resulting output had no audio and wasn't getting renamed. Given that the help calls this "OUTPUT_PATH", one might assume it is indeed looking for a directory. 

This PR checks to see if the argument is a directory, or a file, and responds accordingly.