### PR TITLE
Add image format selector

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -45,6 +45,7 @@ def parse_args() -> None:
     parser.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     parser.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=['cpu'], choices=suggest_execution_providers(), nargs='+')
     parser.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
+    parser.add_argument('--image-format', help='adjust intermediate image format', dest='image_format', default='png', choices=['png', 'jpg'])
 
     # register deprecated args
     parser.add_argument('-f', '--face', help=argparse.SUPPRESS, dest='source_path_deprecated')
@@ -68,6 +69,7 @@ def parse_args() -> None:
     roop.globals.max_memory = args.max_memory
     roop.globals.execution_providers = decode_execution_providers(args.execution_provider)
     roop.globals.execution_threads = args.execution_threads
+    roop.globals.image_format = args.image_format
 
     # warn and cast deprecated args
     if args.source_path_deprecated:

--- a/roop/globals.py
+++ b/roop/globals.py
@@ -11,5 +11,6 @@ video_quality = None
 max_memory = None
 execution_providers = []
 execution_threads = None
+image_format = None
 headless = None
 log_level = 'error'

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -42,13 +42,13 @@ def detect_fps(target_path: str) -> float:
 
 def extract_frames(target_path: str) -> None:
     temp_directory_path = get_temp_directory_path(target_path)
-    run_ffmpeg(['-i', target_path, os.path.join(temp_directory_path, '%04d.png')])
+    run_ffmpeg(['-i', target_path, '-qscale:v', '1', os.path.join(temp_directory_path, '%04d.' + roop.globals.image_format)])
 
 
 def create_video(target_path: str, fps: float = 30.0) -> None:
     temp_output_path = get_temp_output_path(target_path)
     temp_directory_path = get_temp_directory_path(target_path)
-    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, '%04d.png'), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', temp_output_path])
+    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, '%04d.' + roop.globals.image_format), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', temp_output_path])
 
 
 def restore_audio(target_path: str, output_path: str) -> None:
@@ -60,7 +60,7 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    return glob.glob(os.path.join(temp_directory_path, '*.png'))
+    return glob.glob(os.path.join(temp_directory_path, '*.' + roop.globals.image_format))
 
 
 def get_temp_directory_path(target_path: str) -> str:


### PR DESCRIPTION
Sacrifice quality for performance and size. Example 

`time ./run.py -f ../roopvidz/testface.png -t ../roopvidz/testvid.mkv -o ../roopvidz/testresult.mkv  --many-faces --frame-processor face_swapper --keep-fps --execution-provider cuda --max-memory 32 --execution-threads 4  --keep-frames`

```
--image-format jpg: cuda  292.18s user 50.04s system 413% cpu 1:22.70 total
--image-format png: cuda  460.95s user 49.21s system 564% cpu 1:30.44 total
```
Space savings is about 2-4x less with JPG. 

These numbers may not be much but this is only 1700 frames. at 100k+ frames, this is a big difference.

Note that qscale:v 1 makes no difference for png, but sets jpg to maximum quality.