### PR TITLE
process wrong image in face_enhancer

### DIFF
--- a/roop/processors/frame/face_enhancer.py
+++ b/roop/processors/frame/face_enhancer.py
@@ -142,8 +142,8 @@ def process_frames(source_path: str, frame_paths: list[str], progress=None) -> N
             progress.update(1)
 
 
-def process_image(source_path: str, image_path: str, output_file: str) -> None:
-    image = cv2.imread(image_path)
+def process_image(source_path: str, target_path: str, output_file: str) -> None:
+    image = cv2.imread(output_file)
     result = process_frame(None, image)
     cv2.imwrite(output_file, result)
 


### PR DESCRIPTION
According to this line of code in processors/core.py: frame_processor.process_image(roop.globals.source_path, roop.globals.target_path, roop.globals.output_path)

It should process output_file instead of target_path here in process_image(source_path: str, image_path: str, output_file: str).