### PR TITLE
readme update: old keys fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ options:
                         number of execution threads
 ```
 
-Looking for a CLI mode? Using the -f/--face argument will make the program in cli mode.
+Looking for a CLI mode? Using the -s/--source argument will make the program in cli mode.
 
 ## Future plans
 - [ ] Improve the quality of faces in results

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -3,7 +3,7 @@ import customtkinter as ctk
 from typing import Callable, Tuple
 
 import cv2
-from PIL import Image, ImageTk, ImageOps
+from PIL import Image, ImageOps
 
 import roop.globals
 from roop.face_analyser import get_one_face


### PR DESCRIPTION
I noticed that the new keys are missing in the readme.