### PR TITLE
Fix square brackets in the target path

### DIFF
--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -62,7 +62,7 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    return glob.glob(os.path.join(temp_directory_path, '*.png'))
+    return glob.glob1(temp_directory_path, '*.png')
 
 
 def get_temp_directory_path(target_path: str) -> str:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -62,7 +62,7 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    files =  glob.glob('*.png', root_dir=temp_directory_path)
+    files = glob.glob1(temp_directory_path, '*.png')
     return [os.path.join(temp_directory_path, item) for item in files]
 
 

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -2,6 +2,7 @@ import glob
 import mimetypes
 import os
 import platform
+import re
 import shutil
 import ssl
 import subprocess
@@ -62,7 +63,7 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    return glob.glob1(temp_directory_path, '*.png')
+    return glob.glob(re.sub(r'([\[\]])','[\\1]', os.path.join(temp_directory_path, '*.png')))
 
 
 def get_temp_directory_path(target_path: str) -> str:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -2,7 +2,6 @@ import glob
 import mimetypes
 import os
 import platform
-import re
 import shutil
 import ssl
 import subprocess

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -63,7 +63,8 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    return glob.glob(re.sub(r'([\[\]])','[\\1]', os.path.join(temp_directory_path, '*.png')))
+    files =  glob.glob('*.png', root_dir=temp_directory_path)
+    return [os.path.join(temp_directory_path, item) for item in files]
 
 
 def get_temp_directory_path(target_path: str) -> str:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -62,8 +62,7 @@ def restore_audio(target_path: str, output_path: str) -> None:
 
 def get_temp_frame_paths(target_path: str) -> List[str]:
     temp_directory_path = get_temp_directory_path(target_path)
-    files = glob.glob1(temp_directory_path, '*.png')
-    return [os.path.join(temp_directory_path, item) for item in files]
+    return glob.glob((os.path.join(glob.escape(temp_directory_path), '*.png')))
 
 
 def get_temp_directory_path(target_path: str) -> str:


### PR DESCRIPTION
When the target path contains square brackets symbols, swapping process fails without any warning messages.
It is happened because the `glob.glob()` method interprets square brackets as a character class groups.
This PR fixes it.