### PR TITLE
Fixing the colorspace issue when writing the mp4 from the extracted pngs

### DIFF
--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -44,7 +44,7 @@ def detect_fps(target_path: str) -> float:
 
 def extract_frames(target_path: str) -> None:
     temp_directory_path = get_temp_directory_path(target_path)
-    run_ffmpeg(['-i', target_path, os.path.join(temp_directory_path, '%04d.png')])
+    run_ffmpeg(['-i', target_path, '-pix_fmt', 'rgb24', '-sws_flags', '+accurate_rnd+full_chroma_int', '-colorspace', '1', '-color_primaries', '1', '-color_trc', '1', os.path.join(temp_directory_path, '%04d.png')])
 
 
 def create_video(target_path: str, fps: float = 30.0) -> None:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -50,7 +50,7 @@ def extract_frames(target_path: str) -> None:
 def create_video(target_path: str, fps: float = 30.0) -> None:
     temp_output_path = get_temp_output_path(target_path)
     temp_directory_path = get_temp_directory_path(target_path)
-    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, '%04d.png'), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-y', temp_output_path])
+    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, '%04d.png'), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-y', '-pix_fmt', 'yuv420p10le', '-sws_flags', 'spline+accurate_rnd+full_chroma_int', '-vf', 'colorspace=bt709:iall=bt601-6-625:fast=1', '-color_range', '1', '-colorspace', '1', '-color_primaries', '1', '-color_trc', '1', temp_output_path])
 
 
 def restore_audio(target_path: str, output_path: str) -> None:


### PR DESCRIPTION
'-sws_flags', 'spline+accurate_rnd+full_chroma_int', use full color and chroma subsampling
'-vf', 'colorspace=bt709:iall=bt601-6-625:fast=1', keep rec709 (bt709)
 '-color_range', '1', '-colorspace', '1', '-color_primaries', '1', '-color_trc', '1', put the metadata color tags to the png