### PR TITLE
deps: drop torch, torch-cuda and torchvision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 models
 temp
 __pycache__
+.venv

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,8 +5,6 @@ insightface==0.7.3
 psutil==5.9.5
 tk==0.1.0
 customtkinter==5.1.3
-torch==2.0.1
-torchvision==0.15.2
 onnxruntime==1.15.0
 tensorflow==2.12.0
 opennsfw2==0.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---extra-index-url https://download.pytorch.org/whl/cu118
-
 numpy==1.23.5
 opencv-python==4.7.0.72
 onnx==1.14.0
@@ -8,10 +6,6 @@ psutil==5.9.5
 tk==0.1.0
 customtkinter==5.1.3
 pillow==9.5.0
-torch==2.0.1+cu118; sys_platform != 'darwin'
-torch==2.0.1; sys_platform == 'darwin'
-torchvision==0.15.2+cu118; sys_platform != 'darwin'
-torchvision==0.15.2; sys_platform == 'darwin'
 onnxruntime==1.15.0; sys_platform == 'darwin' and platform_machine != 'arm64'
 onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.15.0; sys_platform != 'darwin'

--- a/roop/core.py
+++ b/roop/core.py
@@ -13,7 +13,6 @@ import platform
 import signal
 import shutil
 import argparse
-import torch
 import onnxruntime
 import tensorflow
 
@@ -23,9 +22,6 @@ import roop.ui as ui
 from roop.predicter import predict_image, predict_video
 from roop.processors.frame.core import get_frame_processors_modules
 from roop.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, normalize_output_path
-
-if 'ROCMExecutionProvider' in roop.globals.execution_providers:
-    del torch
 
 warnings.filterwarnings('ignore', category=FutureWarning, module='insightface')
 warnings.filterwarnings('ignore', category=UserWarning, module='torchvision')
@@ -115,11 +111,6 @@ def limit_resources() -> None:
             resource.setrlimit(resource.RLIMIT_DATA, (memory, memory))
 
 
-def release_resources() -> None:
-    if 'CUDAExecutionProvider' in roop.globals.execution_providers:
-        torch.cuda.empty_cache()
-
-
 def pre_check() -> bool:
     if sys.version_info < (3, 9):
         update_status('Python version is not supported - please upgrade to 3.9 or higher.')
@@ -149,7 +140,6 @@ def start() -> None:
             update_status('Progressing...', frame_processor.NAME)
             frame_processor.process_image(roop.globals.source_path, roop.globals.output_path, roop.globals.output_path)
             frame_processor.post_process()
-            release_resources()
         if is_image(roop.globals.target_path):
             update_status('Processing to image succeed!')
         else:
@@ -167,7 +157,6 @@ def start() -> None:
         update_status('Progressing...', frame_processor.NAME)
         frame_processor.process_video(roop.globals.source_path, temp_frame_paths)
         frame_processor.post_process()
-        release_resources()
     # handles fps
     if roop.globals.keep_fps:
         update_status('Detecting fps...')


### PR DESCRIPTION
torch and torchvision are still needed by gfpgan, but the CUDA / CUDNN libraries aren't installed by default anymore now.
This results in a much lesser download time, venv size and lesser startup time (atleast with CPU execution model).