### PR TITLE
Switch get_one_face() to pick the largest one

### DIFF
--- a/roop/face_analyser.py
+++ b/roop/face_analyser.py
@@ -20,9 +20,10 @@ def get_face_analyser() -> Any:
 
 
 def get_one_face(frame: Frame) -> Any:
-    face = get_face_analyser().get(frame)
+    faces = get_face_analyser().get(frame)
     try:
-        return min(face, key=lambda x: x.bbox[0])
+        # Pick the largest face (x2 - x1) * (y2 - y1)
+        return max(faces, key=lambda x: (x.bbox[2] - x.bbox[0]) * (x.bbox[3] - x.bbox[1]))
     except ValueError:
         return None
 


### PR DESCRIPTION
Hi, many times I wished the get_one_face() would pick the one I want but it doesn't. I tried to find concrete docs on the faces' `bbox` but couldn't. I did find [this example](https://github.com/deepinsight/insightface/blob/master/examples/person_detection/scrfd_person.py#L36C24-L36C25) which seems good enough

The current implementation is picking whichever is more to the left. I think a better default (given one HAS to be chosen) is grabbing the largest one. That's usually the one closer to the viewer and the main point of focus.