### PR TITLE
Fix dependency conflict

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,4 @@
-numpy==1.23.5
+numpy==1.24.3
 opencv-python==4.8.0.74
 onnx==1.14.0
 insightface==0.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 
-numpy==1.23.5
+numpy==1.24.3
 opencv-python==4.8.0.74
 onnx==1.14.0
 insightface==0.7.3


### PR DESCRIPTION
On a fresh virtualenv, running `pip install -r requirements.txt` gives the following error

```code
ERROR: Cannot install -r requirements.txt (line 15), -r requirements.txt (line 20), -r requirements.txt (line 4), -r requirements.txt (line 5), -r requirements.txt (line 6) and numpy==1.23.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.23.5
    opencv-python 4.8.0.74 depends on numpy>=1.21.2; python_version >= "3.10"
    opencv-python 4.8.0.74 depends on numpy>=1.23.5; python_version >= "3.11"
    opencv-python 4.8.0.74 depends on numpy>=1.17.0; python_version >= "3.7"
    opencv-python 4.8.0.74 depends on numpy>=1.17.3; python_version >= "3.8"
    opencv-python 4.8.0.74 depends on numpy>=1.19.3; python_version >= "3.9"
    onnx 1.14.0 depends on numpy
    insightface 0.7.3 depends on numpy
    torchvision 0.15.2+cu118 depends on numpy
    onnxruntime-gpu 1.15.1 depends on numpy>=1.24.2
```

- Latest compatible numpy version is `1.24.3`
- numpy `1.25.1` is not compatible (`tensorflow 2.13.0 depends on numpy<=1.24.3 and >=1.22`)